### PR TITLE
Temporarily comment out setting NTP server

### DIFF
--- a/preferences/global.sh
+++ b/preferences/global.sh
@@ -39,8 +39,8 @@ message 'Expand save and print panels' 'substep'
 defaults write -g 'NSNavPanelExpandedStateForSaveMode' -bool true
 defaults write -g 'PMPrintingExpandedStateForPrint' -bool true
 
-message 'Switch to a nearest NTP server' 'substep'
-sudo systemsetup -setnetworktimeserver ntp.nic.cz
+# message 'Switch to a nearest NTP server' 'substep'
+# sudo systemsetup -setnetworktimeserver ntp.nic.cz
 
 message 'Add ~/Git to Spotlight exclusions' 'substep'
 sudo /usr/libexec/PlistBuddy -c "Add :Exclusions:0 string '/Users/krystof-k/Git'" /System/Volumes/Data/.Spotlight-V100/VolumeConfiguration.plist


### PR DESCRIPTION
Probably a bug in macOS 26:

```
sudo systemsetup -setnetworktimeserver ntp.nic.cz
2025-06-21 16:39:53.976 systemsetup[98989:313432] ### Error:-99 File:/AppleInternal/Library/BuildRoots/4~B1IfugCP1-AIJtWvmqTqq-mx3LLbaoYyrILaudY/Library/Caches/com.apple.xbs/Sources/Admin/InternetServices.m Line:379
setNetworkTimeServer: ntp.nic.cz
```