### PR TITLE
Temporarily comment out HP drivers in Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -177,7 +177,7 @@ cask '1kc-razer'
 # - eObčanka
 cask 'eobcanka'
 # - HP printers
-cask 'apple-hewlett-packard-printer-drivers'
+# cask 'apple-hewlett-packard-printer-drivers'
 # - YubiKey
 cask 'yubico-yubikey-manager'
 brew 'yubico-piv-tool'


### PR DESCRIPTION
```
installer: Error - This update requires macOS version 15.0 or earlier.
Error: Failure while executing; `/usr/bin/sudo -u root -E LOGNAME=krystof-k USER=krystof-k USERNAME=krystof-k -- /usr/sbin/installer -pkg /opt/homebrew/Caskroom/apple-hewlett-packard-printer-drivers/5.1.1,2021,071-46903-20211101-0BD2764A-901C-41BA-9573-C17B8FDC4D90/HewlettPackardPrinterDrivers.pkg -target /` exited with 1. Here's the output:
installer: Error - This update requires macOS version 15.0 or earlier.
```