### PR TITLE
Remove `--setloggingmode` from firewall setup

### DIFF
--- a/preferences/global.sh
+++ b/preferences/global.sh
@@ -52,7 +52,6 @@ sudo /usr/libexec/ApplicationFirewall/socketfilterfw \
   --setblockall off \
   --setallowsigned on \
   --setallowsignedapp on \
-  --setloggingmode on \
   --setstealthmode off \
   --setglobalstate on
 


### PR DESCRIPTION
`--setloggingmode` option no longer present in macOS 26.